### PR TITLE
v3_usm.go: add privacy passphrase in extendKeyBlumenthal cacheKey cal…

### DIFF
--- a/v3_usm.go
+++ b/v3_usm.go
@@ -493,12 +493,12 @@ func extendKeyReeder(authProtocol SnmpV3AuthProtocol, password string, engineID 
 // https://tools.ietf.org/html/draft-blumenthal-aes-usm-04#page-7
 // Not many vendors use this algorithm.
 // Previously implemented in the net-snmp and pysnmp libraries.
-// Not tested
+// TODO: Not tested
 func extendKeyBlumenthal(authProtocol SnmpV3AuthProtocol, password string, engineID string) ([]byte, error) {
 	var key []byte
 	var err error
 
-	key, err = hMAC(authProtocol.HashType(), cacheKey(authProtocol, ""), password, engineID)
+	key, err = hMAC(authProtocol.HashType(), cacheKey(authProtocol, password), password, engineID)
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
…l (#425)

alter  ``extendKeyBlumenthal()`` function to include the privacy passphrase for cacheKey calls to prevent the privacy passphrase that was used for the first connection to be incorrectly reused in any later connections.

fixes #424

Signed-off-by: Tim Rots <tim.rots@protonmail.ch>